### PR TITLE
Use loop device for staging ESP

### DIFF
--- a/config/systemd-service/extboot-fix-mount.service
+++ b/config/systemd-service/extboot-fix-mount.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Extboot staging ESP mount fixer
+DefaultDependencies=no
+RequiresMountsFor=/usr/sbin/losetup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/losetup /dev/loop78 /var/lib/extboot/esp.img
+ExecStart=/usr/sbin/losetup --detach /dev/loop78


### PR DESCRIPTION
The staging ESP is moved from VLM logical volume `/dev/vg-primary/extboot-esp`
to loop device `/dev/loop78` with a backing file `/var/lib/extboot/esp.img`.

See the [comment][1].

[1]: https://github.com/yabusygin/extboot/issues/9#issuecomment-810826834

Closes #9