### PR TITLE
Add grub-multi-install wrapper that disables UEFI boot vars updates

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -362,4 +362,27 @@ Installation instructions:
 30. Create file `/etc/udev/rules.d/99-extboot.rules` with contents from
     `${project_root}/config/udev/99-extboot.rules`.
 
-31. Reboot.
+31. Disable UEFI boot variables updates.
+
+    ```sh
+    echo 'set grub2/update_nvram false' | debconf-communicate
+    ```
+
+    To fix the issue #13 run the following command:
+
+    ```sh
+    dpkg-divert \
+        --add \
+        --divert /usr/lib/grub/grub-multi-install.distrib \
+        --rename \
+        /usr/lib/grub/grub-multi-install
+    ```
+
+    and create wrapper script `/usr/lib/grub/grub-multi-install` with contents from
+    `${project_root}/wrapper/grub-multi-install`.
+
+    ```sh
+    chmod +x /usr/lib/grub/grub-multi-install
+    ```
+
+32. Reboot.

--- a/wrapper/grub-multi-install
+++ b/wrapper/grub-multi-install
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# The post-installation script of the `grub-efi-amd64-signed` package ignores
+# the value of the `grub2/update_nvram` debconf variable. This results in boot
+# failures on systems that use extboot. This `grub-multi-install` wrapper fixes
+# the above issue.
+#
+# See extboot issue #13 "Boot fails after GRUB upgrade" for details:
+# https://github.com/yabusygin/extboot/issues/13
+
+set -o errexit
+
+. /usr/share/debconf/confmodule
+
+update_nvram() {
+    db_get grub2/update_nvram
+    if [ "$RET" = "true" ]; then
+        return 0
+    fi
+    return 1
+}
+
+no_nvram() {
+    for arg; do
+        if [ "$arg" = "--no-nvram" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Run the real `grub-multi-install` with `--no-nvram` argument
+# if `grub2/update_nvram` debconf variable value is false.
+
+GRUB_MULTI_INSTALL=/usr/lib/grub/grub-multi-install.distrib
+
+if ! no_nvram "$@" && ! update_nvram; then
+    NO_NVRAM="--no-nvram"
+else
+    NO_NVRAM=""
+fi
+
+$GRUB_MULTI_INSTALL "$NO_NVRAM" "$@"


### PR DESCRIPTION
The post-installation script of the `grub-efi-amd64-signed` package ignores the value of the `grub2/update_nvram` debconf variable. This results in boot failures on systems that use extboot. The `grub-multi-install` wrapper that fixes the above issue is added.

The wrapper runs the real `grub-multi-install` with `--no-nvram` argument if `grub2/update_nvram` debconf variable value is false.

Closes #13